### PR TITLE
Posible inconveniente de la traduccion automatica

### DIFF
--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -389,7 +389,7 @@ ggplot(
     ¿Cuál es el valor predeterminado del argumento?
     Cree un diagrama de dispersión en el que utilice con éxito este argumento con valor `TRUE`.
 
-7.  Agregue el siguiente título al gráfico que hizo en el ejercicio anterior: "Los datos provienen del paquete palmerpenguins".
+7.  Agregue la siguiente etiqueta (o texto explicativo) al gráfico que hizo en el ejercicio anterior: "Los datos provienen del paquete palmerpenguins".
     Sugerencia: Eche un vistazo a la documentación de `labs()`.
 
 8.  Vuelva a crear la siguiente visualización.


### PR DESCRIPTION
En el texto en Ingles utiliza la palabra "caption" que puede traducir subtitulo pero dependiente del contexto tambien puede traducir "etiqueta " o "texto explicativo"

[Texto en español:
](https://davidrsch.github.io/r4dses/data-visualize.html)<img width="916" height="82" alt="image" src="https://github.com/user-attachments/assets/74f761ed-1205-480a-9ec1-127720b187fd" />

[Texto en ingles
](https://r4ds.hadley.nz/data-visualize.html#exercises)<img width="917" height="80" alt="image" src="https://github.com/user-attachments/assets/ef2ef343-286f-4167-959d-578ca47de7ba" />


<img width="1020" height="887" alt="image" src="https://github.com/user-attachments/assets/daf6cfab-cc11-4f8b-9574-33368d5134ff" />


Y por la respuesta que se da en el [apartado de respuestas](https://mine-cetinkaya-rundel.github.io/r4ds-solutions/data-visualize.html) paraser que "Caption" en ese contecto no significan subtitulos


<img width="1045" height="780" alt="image" src="https://github.com/user-attachments/assets/9c1b53ec-90d3-4ba1-a520-81449787e195" />

