### PR TITLE
Error de Traduccion en el apartado 6.1.3 Guardar y nombrar del capitu…

### DIFF
--- a/workflow-scripts.qmd
+++ b/workflow-scripts.qmd
@@ -152,7 +152,7 @@ report-draft-notes.txt
 ```
 
 La numeración de los scripts clave hace que sea obvio en qué orden ejecutarlos y un esquema de nombres consistente hace que sea más fácil ver qué varía.
-Además, las cifras se etiquetan de manera similar, los informes se distinguen por las fechas incluidas en los nombres de los archivos y se cambia el nombre de `temp` a `report-draft-notes` para describir mejor su contenido.
+Además, los gráficos se etiquetan de manera similar, los informes se distinguen por las fechas incluidas en los nombres de los archivos y se cambia el nombre de `temp` a `report-draft-notes` para describir mejor su contenido.
 Si tiene muchos archivos en un directorio, se recomienda llevar la organización un paso más allá y colocar diferentes tipos de archivos (guiones, figuras, etc.) en diferentes directorios.
 
 ## Proyectos


### PR DESCRIPTION
…lo 6  Flujo de trabajo: scripts y proyectos

Hola, en la parte final del apartado 6.1.3, en el capitulo 6, hay un posible error de traduccion que puede hacer a que no se entienda a que se refiere el texto.

[En la traduccion dice:](https://davidrsch.github.io/r4dses/workflow-scripts.html#guardar-y-nombrar)

<img width="930" height="623" alt="image" src="https://github.com/user-attachments/assets/0c974809-a48f-463d-ae36-34ee25ece55d" />


[ Pero en el texto en ingles pone:
](https://r4ds.hadley.nz/workflow-scripts.html#rstudio-diagnostics)  
<img width="980" height="622" alt="image" src="https://github.com/user-attachments/assets/12427ce2-a19b-4447-9316-eda9de7c27bd" />

[Dado que es un libro tecnico de informatica en ese contexto  _**the figures**_ se puede traducir como **los gráficos**](https://www.linguee.es/ingles-espanol/traduccion/figure.html)

<img width="1162" height="980" alt="image" src="https://github.com/user-attachments/assets/d6abd3bc-86e7-4fed-8f32-cfcd63eb3d6d" />
