### PR TITLE
Posible mejora en la traduccion.qmd

### DIFF
--- a/communication.qmd
+++ b/communication.qmd
@@ -62,10 +62,10 @@ ggplot(mpg, aes(x = displ, y = hwy)) +
   geom_point(aes(color = class)) +
   geom_smooth(se = FALSE) +
   labs(
-    x = "Motor desplazamiento (L)",
+    x = "Cilindrada del motor (L)",
     y = "Economía de combustible en carretera (mpg)",
     color = "Tipo de coche",
-    title = "Eficiencia de combustible generalmente disminuye con el tamaño del motor",
+    title = "Eficiencia de combustible generalmente disminuye con la cilindrada del motor",
     subtitle = "Dos plazas son una excepción debido a su peso ligero",
     caption = "Datos de fueleconomy.gov"
   )


### PR DESCRIPTION
En este caso "Motor desplazamiento (L)" no es un termino entendible para el usuario. De pronto es un error de traucción.

Me parece mejor traducirloc mo Cilindrada del motor.
<img width="1018" height="182" alt="image" src="https://github.com/user-attachments/assets/ff919f64-42ee-4d72-8f1f-a9fbc2d9340a" />
