### PR TITLE
fix: recuperar notas al pie faltantes y corregir errores en iteration y missing-values

### DIFF
--- a/iteration.qmd
+++ b/iteration.qmd
@@ -172,10 +172,12 @@ df_miss |>
   )
 ```
 
-Esto es un poco detallado, por lo que R viene con un atajo útil: para este tipo de función desechable, o **anónima**[^iteration-1], puede reemplazar `función` con `\`\[\^iteration-2 \]:
+Esto es un poco detallado, por lo que R viene con un atajo útil: para este tipo de función desechable, o **anónima**[^iteration-1], puede reemplazar `función` con `\(x)`[^iteration-2]:
 
 [^iteration-1]: Anónimo, porque nunca le dimos explícitamente un nombre con `<-`.
     Otro término que usan los programadores para esto es "función lambda".
+
+[^iteration-2]: En código más antiguo es posible que veas una sintaxis como `~ .x + 1`. Es otra forma de escribir funciones anónimas, pero solo funciona dentro de las funciones de tidyverse y siempre usa el nombre de variable `.x`. Ahora recomendamos la sintaxis base, `\(x) x + 1`.
 
 ```{r}
 #| results: false
@@ -223,9 +225,9 @@ Como aprenderá en la siguiente sección, puede usar el argumento `.names` para 
 ### Nombres de columna
 
 El resultado de `across()` se nombra de acuerdo con la especificación provista en el argumento `.names`.
-Podríamos especificar el nuestro si quisiéramos que el nombre de la función fuera primero [^iteration-2]:
+Podríamos especificar el nuestro si quisiéramos que el nombre de la función fuera primero [^iteration-3]:
 
-[^iteration-2]: actualmente no puede cambiar el orden de las columnas, pero podría reordenarlas después usando `relocate()` o similar.
+[^iteration-3]: actualmente no puede cambiar el orden de las columnas, pero podría reordenarlas después usando `relocate()` o similar.
 
 ```{r}
 df_miss |> 
@@ -374,9 +376,9 @@ df_paired <- tibble(
 )
 ```
 
-Actualmente no hay forma de hacer esto con `across()`[^iteration-3], pero es relativamente sencillo con `pivot_longer()`:
+Actualmente no hay forma de hacer esto con `across()`[^iteration-4], pero es relativamente sencillo con `pivot_longer()`:
 
-[^iteration-3]: Tal vez habrá un día, pero actualmente no vemos cómo.
+[^iteration-4]: Tal vez habrá un día, pero actualmente no vemos cómo.
 
 ```{r}
 df_long <- df_paired |> 
@@ -432,7 +434,10 @@ Si es necesario, puede `pivot_wider()` para devolverlo a la forma original.
 
 En la sección anterior, aprendiste a usar `dplyr::across()` para repetir una transformación en varias columnas.
 En esta sección, aprenderá cómo usar `purrr::map()` para hacer algo con cada archivo en un directorio.
-Empecemos con un poco de motivación: imagine que tiene un directorio lleno de hojas de cálculo de Excel[^iteration-4] que desea leer.
+Empecemos con un poco de motivación: imagine que tiene un directorio lleno de hojas de cálculo de Excel[^iteration-5] que desea leer.
+
+[^iteration-5]: Si en cambio tuvieras un directorio de archivos csv con el mismo formato, puedes usar la técnica de la @sec-readr-multiple.
+
 Podrías hacerlo con copiar y pegar:
 
 ```{r}
@@ -732,9 +737,9 @@ files <- paths |>
 ```
 
 Luego, una estrategia muy útil es capturar la estructura de los data frames para que pueda explorarla usando sus habilidades de ciencia de datos.
-Una forma de hacerlo es con esta útil función `df_types` [^iteration-4] que devuelve un tibble con una fila para cada columna:
+Una forma de hacerlo es con esta útil función `df_types` [^iteration-6] que devuelve un tibble con una fila para cada columna:
 
-[^iteration-4]: no vamos a explicar cómo funciona, pero si miras los documentos de las funciones utilizadas, deberías poder descifrarlo.
+[^iteration-6]: no vamos a explicar cómo funciona, pero si miras los documentos de las funciones utilizadas, deberías poder descifrarlo.
 
 ```{r}
 df_types <- function(df) {
@@ -958,7 +963,7 @@ carat_histogram <- function(df) {
 carat_histogram(by_clarity$data[[1]])
 ```
 
-Ahora podemos usar `map()` para crear una lista de muchos gráficos\[\^iterationn-6\] y sus posibles rutas de archivo:
+Ahora podemos usar `map()` para crear una lista de muchos gráficos[^iteration-7] y sus posibles rutas de archivo:
 
 ```{r}
 by_clarity <- by_clarity |> 
@@ -967,6 +972,8 @@ by_clarity <- by_clarity |>
     path = str_glue("clarity-{clarity}.png")
   )
 ```
+
+[^iteration-7]: Puedes imprimir `by_clarity$plot` para obtener una animación rudimentaria: verás un gráfico por cada elemento de `plots`. NOTA: esto no ocurrió en el caso de los autores.
 
 Luego usa `walk2()` con `ggsave()` para guardar cada gráfico:
 

--- a/missing-values.qmd
+++ b/missing-values.qmd
@@ -1,4 +1,4 @@
-# Valores faltanres {#sec-missing-values}
+# Valores faltantes {#sec-missing-values}
 
 ```{r}
 #| echo: false
@@ -275,7 +275,9 @@ length(x2)
 
 Todas las funciones de resumen funcionan con vectores de longitud cero, pero pueden devolver resultados sorprendentes a primera vista.
 Aquí vemos que `mean(age)` devuelve `NaN` porque `mean(age)` = `sum(age)/length(age)` que aquí es 0/0.
-`max()` y `min()` devuelven -Inf e Inf para vectores vacíos, por lo que si combina los resultados con un vector no vacío de nuevos datos y vuelve a calcular, obtendrá el mínimo o el máximo de los nuevos datos\[\^ valores perdidos-1\].
+`max()` y `min()` devuelven -Inf e Inf para vectores vacíos, por lo que si combina los resultados con un vector no vacío de nuevos datos y vuelve a calcular, obtendrá el mínimo o el máximo de los nuevos datos[^missing-values-1].
+
+[^missing-values-1]: En otras palabras, `min(c(x, y))` siempre es igual a `min(min(x), min(y))`.
 
 A veces, un enfoque más simple es realizar el resumen y luego hacer explícitas las faltas implícitas con `complete()`.
 


### PR DESCRIPTION
### iteration.qmd
- Línea 175: texto corrupto reparado — ahora muestra correctamente `\(x)` como atajo para funciones anónimas
- Renumeración completa de notas al pie (iteration-2 a iteration-7) para coincidir con el original en inglés, que tiene 7 notas pero la traducción solo tenía 5
- Recuperadas tres notas al pie que desaparecieron en la traducción:
  - `[^iteration-2]`: explica la sintaxis antigua `~ .x + 1`
  - `[^iteration-5]`: alternativa con directorio de csvs en vez de Excel
  - `[^iteration-7]`: sobre imprimir `by_clarity$plot` para animación
- Eliminada la duplicación de `[^iteration-4]` que apuntaba a dos referencias distintas con la misma definición

### missing-values.qmd
- Título del capítulo: "Valores faltanres" → "Valores faltantes"
- Recuperada nota al pie faltante `[^missing-values-1]` con su definición original: "En otras palabras, `min(c(x, y))` siempre es igual a `min(min(x), min(y))`."