### PR TITLE
fix: corregir errores en data-visualize, workflow-basics, data-transform, workflow-style y data-tidy

### DIFF
--- a/data-tidy.qmd
+++ b/data-tidy.qmd
@@ -124,7 +124,7 @@ ggplot(table1, aes(x = year, y = cases)) +
 
 1.  Para cada una de las tablas de muestra, describa lo que representa cada observación y cada columna.
 
-2.  Haz un bosquejo del proceso que usarías para calcular la `rate` desde `table2`.
+2.  Haz un bosquejo del proceso que usarías para calcular la `rate` desde `table2` y `table3`.
     Deberá realizar cuatro operaciones:
 
     a.  Extraiga el número de casos de TB por país por año.
@@ -337,7 +337,7 @@ knitr::include_graphics("diagrams/tidy-data/cell-values.png", dpi = 270)
 ### Muchas variables en los nombres de las columnas
 
 Una situación más desafiante ocurre cuando tiene múltiples piezas de información abarrotadas en los nombres de las columnas y desea almacenarlas en nuevas variables separadas.
-Por ejemplo, tome el conjunto de datos `who2`, la fuente de `table_1` y amigos que vió con anterioridad:
+Por ejemplo, tome el conjunto de datos `who2`, la fuente de `table1` y amigos que vió con anterioridad:
 
 ```{r}
 who2
@@ -585,8 +585,7 @@ Esto es en parte un reflejo de nuestra definición de datos ordenados, donde dij
 Está totalmente bien ser pragmático y decir que una variable es lo que hace que su análisis sea más fácil.
 Entonces, si no sabe cómo hacer algunos cálculos, considere cambiar la organización de sus datos; ¡no tenga miedo de desordenar, transformar y volver a ordenar según sea necesario!
 
-Si disfrutó de este capítulo y desea obtener más información sobre la teoría subyacente, puede obtener más información sobre la historia y los fundamentos teóricos en el artículo [Tidy Data](https://www.jstatsoft.org/article/view/v059i10) publicado.
-en el Journal of Statistical Software.
+Si disfrutó de este capítulo y desea obtener más información sobre la teoría subyacente, puede obtener más información sobre la historia y los fundamentos teóricos en el artículo [Tidy Data](https://www.jstatsoft.org/article/view/v059i10) publicado en el Journal of Statistical Software.
 
 Ahora que está escribiendo una cantidad sustancial de código R, es hora de aprender más sobre cómo organizar su código en archivos y directorios.
 En el próximo capítulo, aprenderá todo acerca de las ventajas de los scripts y proyectos, y algunas de las muchas herramientas que brindan para facilitarle la vida.

--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -185,7 +185,8 @@ flights |>
 1.  En una canalización única para cada condición, busque todos los vuelos que cumplan la condición:
 
     -   Tuvo un retraso de llegada de dos o más horas.
-    -   Voló a Houston (`IAH` o `HOU`) C. Fueron operados por United, American o Delta
+    -   Voló a Houston (`IAH` o `HOU`)
+    -   Fueron operados por United, American o Delta
     -   Salida en verano (julio, agosto y septiembre)
     -   Llegó más de dos horas tarde, pero no se fue tarde
     -   Se retrasaron al menos una hora, pero recuperaron más de 30 minutos en vuelo
@@ -366,7 +367,7 @@ ggplot(flights, aes(x = dep_sched %% 60)) + geom_histogram(binwidth = 1)
 ggplot(flights, aes(x = air_time - airtime2)) + geom_histogram()
 ```
 
-1.  Compare `dep_time`, `sched_dep_time`, and `dep_delay`.
+1.  Compare `dep_time`, `sched_dep_time` y `dep_delay`. ¿Cómo esperarías que se relacionen esos tres números?
 
 2.  Haga una lluvia de ideas sobre tantas formas como sea posible para seleccionar `dep_time`, `dep_delay`, `arr_time` y `arr_delay` de `flights`.
 
@@ -446,8 +447,6 @@ arrange(flights3, desc(speed))
 Si bien ambas formas tienen su tiempo y lugar, la canalización generalmente produce un código de análisis de datos que es más fácil de escribir y leer.
 
 Para agregar la canalización a su código, recomendamos usar el atajo de teclado incorporado Ctrl/Cmd + Shift + M. Deberá realizar un cambio en sus opciones de RStudio para usar `|>` en lugar de `%>%` como se muestra en @fig-pipe-options; más sobre `%>%` en breve.
-
-485
 
 ```{r}
 #| label: fig-pipe-options
@@ -550,7 +549,7 @@ flights |>
   relocate(dest)
 ```
 
-Tenga en cuenta que hay 105 destinos, pero aquí tenemos 108 filas. ¿Qué pasa? `slice_min()` y `slice_max()` mantienen valores empatados por lo que `n = 1` significa darme todas las filas con el valor más alto. Si desea exactamente una fila por grupo, puede configurar `whit_ties = FALSE`.
+Tenga en cuenta que hay 105 destinos, pero aquí tenemos 108 filas. ¿Qué pasa? `slice_min()` y `slice_max()` mantienen valores empatados por lo que `n = 1` significa darme todas las filas con el valor más alto. Si desea exactamente una fila por grupo, puede configurar `with_ties = FALSE`.
 
 Esto es similar a calcular el retraso máximo con `summarize()`, pero obtienes la fila correspondiente completa (o filas si hay un empate) en lugar de la estadística de resumen única.
 
@@ -637,7 +636,7 @@ flights |>
 
 `.by` funciona con todos los verbos y tiene la ventaja de que no necesita usar el argumento `.groups` para suprimir el mensaje de agrupación o `ungroup()` cuando haya terminado.
 
-No nos enfocamos en esta sintaxis en este capítulo porque era muy nueva cuando se escribió el libro. Queríamos mencionarlo porque creemos que es muy prometedor y es probable que sea bastante popular. Puede obtener más información al respecto en la \[publicación de blog de dplyr 1.1.0\] (https://www.tidyverse.org/blog/2023/02/dplyr-1-1-0-per-operation-grouping/).
+No nos enfocamos en esta sintaxis en este capítulo porque era muy nueva cuando se escribió el libro. Queríamos mencionarlo porque creemos que es muy prometedor y es probable que sea bastante popular. Puede obtener más información al respecto en la [publicación de blog de dplyr 1.1.0](https://www.tidyverse.org/blog/2023/02/dplyr-1-1-0-per-operation-grouping/).
 
 ### Ejercicios
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -104,7 +104,7 @@ En tidyverse, usamos data frames especiales llamados **tibbles** sobre los que a
 penguins
 ```
 
-Este data frame contiene columnas `r ncol (penguins)`.
+Este data frame contiene `r ncol(penguins)` columnas.
 Para una vista alternativa, donde puede ver todas las variables y las primeras observaciones de cada variable, use `glimpse()`.
 O, si está en RStudio, ejecute `View(penguins)` para abrir un visor de datos interactivo.
 
@@ -157,7 +157,8 @@ ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
 Recreemos esta gráfica paso a paso.
 
 Con ggplot2, comienza una gráfica con la función `ggplot()`, definiendo un objeto de gráfica al que luego agrega **capas**.
-El primer argumento de `ggplot()` es el conjunto de datos que se usará en el gráfico, por lo que `ggplot(data = penguins)` crea un gráfico vacío que está preparado para mostrar los datos de `penguins`, pero como no lo hemos dicho cómo visualizarlo todavía, por ahora está vacío.
+El primer argumento de `ggplot()` es el conjunto de datos que se usará en el gráfico, por lo que `ggplot(data = penguins)` crea un gráfico vacío que está preparado para mostrar los datos de `penguins`, pero como no le hemos dicho cómo visualizarlo todavía, por ahora está vacío.
+No es un gráfico muy emocionante, pero puedes pensarlo como un lienzo vacío sobre el que pintarás las capas restantes de tu gráfico.
 
 ```{r}
 #| fig-alt: >

--- a/iteration.qmd
+++ b/iteration.qmd
@@ -436,7 +436,7 @@ En la sección anterior, aprendiste a usar `dplyr::across()` para repetir una tr
 En esta sección, aprenderá cómo usar `purrr::map()` para hacer algo con cada archivo en un directorio.
 Empecemos con un poco de motivación: imagine que tiene un directorio lleno de hojas de cálculo de Excel[^iteration-5] que desea leer.
 
-[^iteration-5]: Si en cambio tuvieras un directorio de archivos csv con el mismo formato, puedes usar la técnica de la @sec-readr-multiple.
+[^iteration-5]: Si en cambio tuvieras un directorio de archivos csv con el mismo formato, puedes usar la técnica de la @sec-readr-directory.
 
 Podrías hacerlo con copiar y pegar:
 

--- a/workflow-basics.qmd
+++ b/workflow-basics.qmd
@@ -59,7 +59,7 @@ Al leer ese código, diga "el nombre del objeto obtiene valor" en su cabeza.
 Hará muchas asignaciones, y `<-` es una molestia escribir.
 Puede ahorrar tiempo con el método abreviado de teclado de RStudio: Alt + - (el signo menos).
 Tenga en cuenta que RStudio rodea automáticamente `<-` con espacios, lo cual es una buena práctica de formateo de código.
-El código puede ser para leer en un buen día, así que tómese un respiro y use espacios.
+El código puede ser miserable para leer incluso en un buen día, así que dale un descanso a tus ojos y usa espacios.
 
 ## Comentarios
 

--- a/workflow-style.qmd
+++ b/workflow-style.qmd
@@ -172,7 +172,7 @@ flights|>
              n = n()
            )
 
-# Avoid
+# Ejemplo de como no debe ser:
 flights|>
   group_by(tailnum) |> 
   summarize(
@@ -203,7 +203,7 @@ Trate de dividirlas en subtareas más pequeñas, dando a cada tarea un nombre in
 Los nombres ayudarán al lector a comprender lo que está sucediendo y facilitarán la verificación de que los resultados intermedios son los esperados.
 Siempre que pueda dar a algo un nombre informativo, debe darle un nombre informativo, por ejemplo, cuando cambia fundamentalmente la estructura de los datos, por ejemplo, después de pivotar o resumir.
 ¡No esperes hacerlo bien la primera vez!
-Esto significa romper canalizacionesías largas si hay estados intermedios que pueden obtener buenos nombres.
+Esto significa romper canalizaciones largas si hay estados intermedios que pueden obtener buenos nombres.
 
 ## ggplot2
 


### PR DESCRIPTION
Correcciones de errores en 5 capítulos.

### data-visualize.qmd
- `ncol (penguins)` → `ncol(penguins)` y reordenada la frase a "contiene 8 columnas"
- `no lo hemos dicho` → `no le hemos dicho` (pronombre incorrecto)
- Recuperada oración omitida: "No es un gráfico muy emocionante, pero puedes pensarlo como un lienzo vacío sobre el que pintarás las capas restantes"

### workflow-basics.qmd
- Recuperada palabra clave omitida: "El código puede ser miserable para leer incluso en un buen día, así que dale un descanso a tus ojos y usa espacios" (el original dice "Code can be miserable to read on a good day, so giveyoureyesabreak and use spaces")

### data-transform.qmd
- Dos viñetas fusionadas en una con "C." intruso separadas correctamente
- Pregunta del ejercicio omitida: "¿Cómo esperarías que se relacionen esos tres números?"
- Eliminado número suelto "485" sin contexto (artefacto de traducción)
- `whit_ties = FALSE` → `with_ties = FALSE` (typo en nombre de argumento)
- Link roto con corchetes escapados: `\[publicación...\] (url)` → `[publicación...](url)`

### workflow-style.qmd
- `canalizacionesías` → `canalizaciones` (sílaba duplicada)
- `# Avoid` → `# Ejemplo de como no debe ser:` (único comentario que quedó  en inglés, todos los demás estaban traducidos)

### data-tidy.qmd
- Ejercicio incompleto: faltaba "y `table3`" en referencia a las tablas
- `table_1` → `table1` (nombre de variable incorrecto)
- Oración partida con punto erróneo: "publicado. en el Journal" → "publicado en el Journal of Statistical Software"